### PR TITLE
kirbytag

### DIFF
--- a/autoid.php
+++ b/autoid.php
@@ -145,36 +145,35 @@ kirby()->hook('panel.page.update', function($page) use ($plugin) {
 
 
 kirbytext::$tags['autoid'] = array(
-  'attr' => array(
-    'text'
-  ),
-  'html' => function($tag) {
-    // Field name to search for
-    $fieldName = c::get('autoid.name', 'autoid');
+    'attr' => array(
+        'text'
+    ),
+    'html' => function($tag) {
+        // Field name to search for
+        $fieldName = c::get('autoid.name', 'autoid');
 
-    // Make use of the entered value
-    $autoid = $tag->attr('autoid');
-    $text   = $tag->attr('text', NULL);
+        // Make use of the entered value
+        $autoid = $tag->attr('autoid');
+        $text   = $tag->attr('text', NULL);
 
-    // Find coresponding page
-    $targets   = site()->index()->filterBy($fieldName, '==' , $autoid)->limit(1);
+        // Find coresponding page
+        $targets   = site()->index()->filterBy($fieldName, '==' , $autoid)->limit(1);
     
-    if (!$targets->count()) {
-        // No page with this autoid
-        return;
-    }
-
-    foreach ($targets as $target) {
-        // Use page title as link text if no text has been entered
-        if (!$text) {
-            $text = $target->title()->html();
+        if (!$targets->count()) {
+            // No page with this autoid
+            return;
         }
 
-        // Get the page url
-        $url  = $target->url();
-    }
-    
-    return '<a href="' . $url . '">' . $text . '</a>';
+        foreach ($targets as $target) {
+            // Use page title as link text if no text has been entered
+            if (!$text) {
+                $text = $target->title()->html();
+            }
 
-  }
+            // Get the page url
+            $url  = $target->url();
+        }
+        
+        return '<a href="' . $url . '">' . $text . '</a>';
+    }
 );

--- a/autoid.php
+++ b/autoid.php
@@ -142,3 +142,39 @@ kirby()->hook('panel.page.update', function($page) use ($plugin) {
         // do nothing, because of a kirby bug: https://github.com/getkirby/panel/issues/667
     }
 });
+
+
+kirbytext::$tags['autoid'] = array(
+  'attr' => array(
+    'text'
+  ),
+  'html' => function($tag) {
+    // Field name to search for
+    $fieldName = c::get('autoid.name', 'autoid');
+
+    // Make use of the entered value
+    $autoid = $tag->attr('autoid');
+    $text   = $tag->attr('text', NULL);
+
+    // Find coresponding page
+    $targets   = site()->index()->filterBy($fieldName, '==' , $autoid)->limit(1);
+    
+    if (!$targets->count()) {
+        // No page with this autoid
+        return;
+    }
+
+    foreach ($targets as $target) {
+        // Use page title as link text if no text has been entered
+        if (!$text) {
+            $text = $target->title()->html();
+        }
+
+        // Get the page url
+        $url  = $target->url();
+    }
+    
+    return '<a href="' . $url . '">' . $text . '</a>';
+
+  }
+);


### PR DESCRIPTION
Hey guys,

Great and very useful little plugin! I've created a kirbytag which allows you to use the autoid inside a mardown textarea as link tag, e.g. `(autoid: 5 text: Linktext)`. If no text is given the targets page title will be used. I've tested it in a multi-language environment and also with `c::set('autoid.type', 'hash');`

What do you think?

Regards,
Flo.
